### PR TITLE
Feature/controller guard

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -3,37 +3,46 @@
 namespace ZfcAcl;
 
 use Zend\Module\Manager,
-    Zend\Mvc\AppContext as Application,
-    Zend\EventManager\StaticEventManager,
-    Zend\EventManager\EventDescription as Event,
-    Zend\Mvc\MvcEvent as MvcEvent,
-    ZfcBase\Module\ModuleAbstract;
+Zend\Mvc\AppContext as Application,
+Zend\EventManager\StaticEventManager,
+Zend\EventManager\EventDescription as Event,
+Zend\Mvc\MvcEvent as MvcEvent,
+ZfcBase\Module\ModuleAbstract;
 
-class Module extends ModuleAbstract {
-    
-    public function bootstrap(Manager $moduleManager, Application $app) {
-        $locator      = $app->getLocator();
-        
+class Module extends ModuleAbstract
+{
+
+    public function bootstrap(Manager $moduleManager, Application $app)
+    {
+        $locator = $app->getLocator();
+
         $events = StaticEventManager::getInstance();
-        
-        if($this->getOption('enable_guards.route', true)) {
+
+        if ($this->getOption('enable_guards.route', true)) {
             $routeProtector = $locator->get('ZfcAcl\Guard\Route');
             $app->events()->attach('dispatch', array($routeProtector, 'dispatch'), 1000);
         }
-        
-        if($this->getOption('enable_guards.event', true)) {
+
+        if ($this->getOption('enable_guards.event', true)) {
             $guard = $locator->get('ZfcAcl\Guard\Event');
             $guard->bootstrap();
         }
-        
+
+        if ($this->getOption('enable_guards.dispatch', true)) {
+            $guard = $locator->get('ZfcAcl\Guard\Dispatch');
+            $app->events()->attach('dispatch', array($guard, 'dispatch'), 1000);
+        }
+
     }
-    
-    public function getDir() {
+
+    public function getDir()
+    {
         return __DIR__;
     }
-    
-    public function getNamespace() {
+
+    public function getNamespace()
+    {
         return __NAMESPACE__;
     }
-    
+
 }

--- a/Module.php
+++ b/Module.php
@@ -3,15 +3,14 @@
 namespace ZfcAcl;
 
 use Zend\Module\Manager,
-Zend\Mvc\AppContext as Application,
-Zend\EventManager\StaticEventManager,
-Zend\EventManager\EventDescription as Event,
-Zend\Mvc\MvcEvent as MvcEvent,
-ZfcBase\Module\ModuleAbstract;
+    Zend\Mvc\AppContext as Application,
+    Zend\EventManager\StaticEventManager,
+    Zend\EventManager\EventDescription as Event,
+    Zend\Mvc\MvcEvent as MvcEvent,
+    ZfcBase\Module\ModuleAbstract;
 
 class Module extends ModuleAbstract
 {
-
     public function bootstrap(Manager $moduleManager, Application $app)
     {
         $locator = $app->getLocator();

--- a/config/ZfcAcl.global.config.php.dist
+++ b/config/ZfcAcl.global.config.php.dist
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Local Configuration Override for ZfcAcl
+ *
+ * This file is shipped to allow easy setup of ZfcAcl with the ZendSkeletonApplication
+ * Application module.
+ *
+ * This configuration override file is for overriding environment-specific and
+ * security-sensitive configuration information. Copy this file without the
+ * .dist extension at the end and populate values as needed.
+ */
+
+return array(
+
+    'ZfcAcl' => array(
+        'options' => array(
+
+            // enable static acl session cache
+            'enable_cache' => false,
+
+            'enable_guards' => array(
+                // Enabling route and dispatch guards
+                'route'     => true,
+                'event'     => false,
+                'dispatch'  => true,
+            ),
+        ),
+    ),
+
+    'di' => array(
+        'instance' => array(
+            // Factory used to populate the Acl
+            'ZfcAcl\Model\Mapper\AclLoaderConfig' => array(
+                'parameters' => array(
+                    'config' => array(
+                        'resources' => array(
+
+                            // ACL Resource IDs for routes defined in the Application module
+                            'Route/Default' => null,
+                            'Route/Home' => null,
+
+                            // ACL Resource IDs for controllers defined in the Application module
+                            'dispatchable/Application\\Controller\\IndexController' => null,
+
+                        ),
+                        'roles' => array(
+
+                            // Configuring default roles
+                            'guest' => null,
+                            'auth' => null,
+                            'user' => null,
+
+                        ),
+                        'rules' => array(
+                            'allow' => array(
+
+                                // Enabling access to routes defined in Application module to all default roles
+                                'allow/Route/Default' => array(array('guest', 'auth', 'user'), 'Route/Default'),
+                                'allow/Route/Home' => array(array('guest', 'auth', 'user'), 'Route/Home'),
+
+                                // Enabling access to controllers defined in Application module to all default roles
+                                'allow/Application\\Controller\\IndexController' => array(
+                                    array('guest', 'auth', 'user'),
+                                    'dispatchable/Application\\Controller\\IndexController',
+                                ),
+
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+
+            'ZfcAcl\Model\Mapper\RouteResourceMapConfig' => array(
+                'parameters' => array(
+                    'config' => array(
+
+                        // mapping routes to their resource ids
+                        'default' => 'Route/Default',
+                        'home' => 'Route/Home',
+
+                    ),
+                ),
+            ),
+        ),
+    ),
+);

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -5,9 +5,9 @@ return array(
             // enable static acl session cache
             'enable_cache' => false,
             'enable_guards' => array(
-                'route' => false,
-                'event' => false,
-                'dispatch' => true,
+                'route'     => false,
+                'event'     => false,
+                'dispatch'  => false,
             ),
         ),
     ),
@@ -18,6 +18,7 @@ return array(
             'ZfcAcl\Service\Acl' => array(
                 'parameters' => array(
                     'aclLoader' => 'ZfcAcl\Model\Mapper\AclLoaderConfig',
+                    'roleProvider' => 'ZfcAcl\Service\Acl\GenericRoleProvider',
                 ),
             ),
 
@@ -34,17 +35,21 @@ return array(
                     'config' => array(
                         'resources' => array(
                             //'Route/Default' => null,//used by ZfcAcl\Guard\Route
+                            // 'resource-id-1' => array('parent-resource-id-1', 'parent-resource-id-2'),
+                            // 'resource-id-2' => null,
                         ),
                         'roles' => array(
-                            'guest' => null,
-                            'auth' => null,
-                            'user' => null,
+                            // 'role-id-1' => array('parent-role-id-1', 'parent-role-id-2'),
+                            // 'role-id-2' => null
                         ),
                         'rules' => array(
                             'allow' => array(
-                                //'allow/default_route' => array(array('auth', 'guest'), 'Route/Default'),
-                            )
-                        )
+                                // Keys in these array are just for allowing overrides, the syntax is:
+                                // 'somekey' => array( array('role1', 'role2', 'role3'),'resource-id')
+                            ),
+                            'deny' => array(
+                            ),
+                        ),
                     ),
                 ),
             ),
@@ -54,21 +59,21 @@ return array(
                 'parameters' => array(
                     'aclService' => 'ZfcAcl\Service\Acl',
                     'routeResourceMapMapper' => 'ZfcAcl\Model\Mapper\RouteResourceMapConfig',
-                )
+                ),
             ),
 
             // Maps routes to resources
             'ZfcAcl\Model\Mapper\RouteResourceMapConfig' => array(
                 'parameters' => array(
                     'config' => array(
-                        //'default' => 'Route/Default',
-                        'child_map' => array(
-                            'default' => array(
-                                //'default' => 'Route/Default',
-                            )
-                        )
-                    )
-                )
+                        // 'route-1' => 'resource-id-for-route-1'
+                        // 'child_map' => array(
+                        //     'route-1' => array(
+                        //         'child-route-1' => 'resource-id-for-child-route-1',
+                        //     ),
+                        // ),
+                    ),
+                ),
             ),
 
             // Event guard
@@ -76,15 +81,15 @@ return array(
                 'parameters' => array(
                     'aclService' => 'ZfcAcl\Service\Acl',
                     'eventGuardDefMapper' => 'ZfcAcl\Model\Mapper\EventGuardDefMapConfig',
-                )
+                ),
             ),
 
             // Dispatch guard
             'ZfcAcl\Guard\Dispatch' => array(
                 'parameters' => array(
                     'aclService' => 'ZfcAcl\Service\Acl',
-                    'dispatchableResourceMap' => 'ZfcAcl\Model\Mapper\DispatchableResourceMap',
-                )
+                    'dispatchableResourceMapper' => 'ZfcAcl\Model\Mapper\DispatchableResourceMapper',
+                ),
             ),
         ),
     ),

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -2,25 +2,33 @@
 return array(
     'ZfcAcl' => array(
         'options' => array(
-            'enable_cache' => false,//enable static acl session cache 
+            // enable static acl session cache
+            'enable_cache' => false,
             'enable_guards' => array(
-                'route' => false,//enable route guard
-                'event' => false,//enable event guard
+                'route' => false,
+                'event' => false,
+                'dispatch' => true,
             ),
         ),
     ),
     'di' => array(
         'instance' => array(
+
+            // Service providing ACLs
             'ZfcAcl\Service\Acl' => array(
                 'parameters' => array(
                     'aclLoader' => 'ZfcAcl\Model\Mapper\AclLoaderConfig',
                 ),
             ),
+
+            // Context providing the current role
             'ZfcAcl\Service\Context' => array(
                 'parameters' => array(
                     'aclService' => 'ZfcAcl\Service\Acl',
                 ),
             ),
+
+            // Factory used to populate the Acl
             'ZfcAcl\Model\Mapper\AclLoaderConfig' => array(
                 'parameters' => array(
                     'config' => array(
@@ -40,12 +48,16 @@ return array(
                     ),
                 ),
             ),
+
+            // Route guard
             'ZfcAcl\Guard\Route' => array(
                 'parameters' => array(
                     'aclService' => 'ZfcAcl\Service\Acl',
                     'routeResourceMapMapper' => 'ZfcAcl\Model\Mapper\RouteResourceMapConfig',
                 )
             ),
+
+            // Maps routes to resources
             'ZfcAcl\Model\Mapper\RouteResourceMapConfig' => array(
                 'parameters' => array(
                     'config' => array(
@@ -58,10 +70,20 @@ return array(
                     )
                 )
             ),
+
+            // Event guard
             'ZfcAcl\Guard\Event' => array(
                 'parameters' => array(
                     'aclService' => 'ZfcAcl\Service\Acl',
                     'eventGuardDefMapper' => 'ZfcAcl\Model\Mapper\EventGuardDefMapConfig',
+                )
+            ),
+
+            // Dispatch guard
+            'ZfcAcl\Guard\Dispatch' => array(
+                'parameters' => array(
+                    'aclService' => 'ZfcAcl\Service\Acl',
+                    'dispatchableResourceMap' => 'ZfcAcl\Model\Mapper\DispatchableResourceMap',
                 )
             ),
         ),

--- a/src/ZfcAcl/Guard/Dispatch.php
+++ b/src/ZfcAcl/Guard/Dispatch.php
@@ -4,7 +4,7 @@ namespace ZfcAcl\Guard;
 
 use Zend\Mvc\MvcEvent,
     ZfcAcl\Exception\UnauthorizedException,
-    ZfcAcl\Model\Mapper\DispatchableResourceMap,
+    ZfcAcl\Model\Mapper\DispatchableResourceMapperInterface,
     ZfcAcl\Service\Acl as AclService;
 
 /**
@@ -13,9 +13,9 @@ use Zend\Mvc\MvcEvent,
 class Dispatch implements Guard
 {
     /**
-     * @var DispatchableResourceMap
+     * @var DispatchableResourceMapperInterface
      */
-    protected $dispatchableResourceMap;
+    protected $dispatchableResourceMapper;
 
     /**
      * @var AclService
@@ -30,7 +30,7 @@ class Dispatch implements Guard
             // Can't check against null
             return;
         }
-        $controllerResource = $this->dispatchableResourceMap->getControllerResource($controller);
+        $controllerResource = $this->dispatchableResourceMapper->getDispatchableResource($controller);
 
         if (!$this->aclService->isAllowed($controllerResource)) {
             throw new UnauthorizedException(
@@ -40,14 +40,20 @@ class Dispatch implements Guard
         }
     }
 
-    public function getDispatchableResourceMap()
+    /**
+     * @return DispatchableResourceMapperInterface
+     */
+    public function getDispatchableResourceMapper()
     {
-        return $this->dispatchableResourceMap;
+        return $this->dispatchableResourceMapper;
     }
 
-    public function setDispatchableResourceMap(DispatchableResourceMap $dispatchableResourceMap)
+    /**
+     * @param DispatchableResourceMapperInterface $dispatchableResourceMapper
+     */
+    public function setDispatchableResourceMap(DispatchableResourceMapperInterface $dispatchableResourceMapper)
     {
-        $this->dispatchableResourceMap = $dispatchableResourceMap;
+        $this->dispatchableResourceMapper = $dispatchableResourceMapper;
     }
 
     public function getAclService()

--- a/src/ZfcAcl/Guard/Dispatch.php
+++ b/src/ZfcAcl/Guard/Dispatch.php
@@ -18,6 +18,14 @@ class Dispatch implements Guard
     protected $dispatchableResourceMapper;
 
     /**
+     * @param DispatchableResourceMapperInterface $dispatchableResourceMapper
+     */
+    public function __construct(DispatchableResourceMapperInterface $dispatchableResourceMapper)
+    {
+        $this->setDispatchableResourceMapper($dispatchableResourceMapper);
+    }
+
+    /**
      * @var AclService
      */
     protected $aclService;
@@ -51,7 +59,7 @@ class Dispatch implements Guard
     /**
      * @param DispatchableResourceMapperInterface $dispatchableResourceMapper
      */
-    public function setDispatchableResourceMap(DispatchableResourceMapperInterface $dispatchableResourceMapper)
+    public function setDispatchableResourceMapper(DispatchableResourceMapperInterface $dispatchableResourceMapper)
     {
         $this->dispatchableResourceMapper = $dispatchableResourceMapper;
     }

--- a/src/ZfcAcl/Guard/Dispatch.php
+++ b/src/ZfcAcl/Guard/Dispatch.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace ZfcAcl\Guard;
+
+use Zend\Mvc\MvcEvent,
+    ZfcAcl\Exception\UnauthorizedException,
+    ZfcAcl\Model\Mapper\DispatchableResourceMap,
+    ZfcAcl\Service\Acl as AclService;
+
+/**
+ * Dispatch guard applies ACL checks the controller that has been requested
+ */
+class Dispatch implements Guard
+{
+    /**
+     * @var DispatchableResourceMap
+     */
+    protected $dispatchableResourceMap;
+
+    /**
+     * @var AclService
+     */
+    protected $aclService;
+
+    public function dispatch(MvcEvent $e)
+    {
+        // @todo this logic should somehow be shared with Zend\Mvc\Application
+        $controller = $e->getRouteMatch()->getParam('controller', 'not-found');
+        if (!$controller) {
+            // Can't check against null
+            return;
+        }
+        $controllerResource = $this->dispatchableResourceMap->getControllerResource($controller);
+
+        if (!$this->aclService->isAllowed($controllerResource)) {
+            throw new UnauthorizedException(
+                $this->aclService->getRole()->getRoleId() . ' is not allowed to access dispatchable '
+                . $controller . ' (' . $controllerResource . ')'
+            );
+        }
+    }
+
+    public function getDispatchableResourceMap()
+    {
+        return $this->dispatchableResourceMap;
+    }
+
+    public function setDispatchableResourceMap(DispatchableResourceMap $dispatchableResourceMap)
+    {
+        $this->dispatchableResourceMap = $dispatchableResourceMap;
+    }
+
+    public function getAclService()
+    {
+        return $this->aclService;
+    }
+
+    public function setAclService(AclService $aclService)
+    {
+        $this->aclService = $aclService;
+    }
+}

--- a/src/ZfcAcl/Model/Mapper/DispatchableResourceMap.php
+++ b/src/ZfcAcl/Model/Mapper/DispatchableResourceMap.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ZfcAcl\Model\Mapper;
+
+use ZfcBase\Model\ModelAbstract;
+
+class DispatchableResourceMap extends ModelAbstract
+{
+    const DEFAULT_RESOURCE_PREFIX = 'dispatchable/';
+
+    /**
+     * @var string prefix to be used for resource names for controllers
+     */
+    protected $resourcePrefix = self::DEFAULT_RESOURCE_PREFIX;
+
+    /**
+     * Retrieves the resource id associated with the given controller name
+     *
+     * @param string $controllerName
+     * @return string
+     */
+    public function getControllerResource($controllerName)
+    {
+        return $this->resourcePrefix . $controllerName;
+    }
+
+    /**
+     * @param string $resourcePrefix
+     */
+    public function setResourcePrefix($resourcePrefix)
+    {
+        $this->resourcePrefix = (string) $resourcePrefix;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResourcePrefix()
+    {
+        return $this->resourcePrefix;
+    }
+}

--- a/src/ZfcAcl/Model/Mapper/DispatchableResourceMapper.php
+++ b/src/ZfcAcl/Model/Mapper/DispatchableResourceMapper.php
@@ -4,7 +4,12 @@ namespace ZfcAcl\Model\Mapper;
 
 use ZfcBase\Model\ModelAbstract;
 
-class DispatchableResourceMap extends ModelAbstract
+/**
+ * Simply maps provided dispatchable names to resource names. In this case by simply adding some prefix.
+ *
+ * @todo add method to reverse mappings?
+ */
+class DispatchableResourceMapper extends ModelAbstract implements DispatchableResourceMapperInterface
 {
     const DEFAULT_RESOURCE_PREFIX = 'dispatchable/';
 
@@ -14,14 +19,11 @@ class DispatchableResourceMap extends ModelAbstract
     protected $resourcePrefix = self::DEFAULT_RESOURCE_PREFIX;
 
     /**
-     * Retrieves the resource id associated with the given controller name
-     *
-     * @param string $controllerName
-     * @return string
+     * {@inheritDoc}
      */
-    public function getControllerResource($controllerName)
+    public function getDispatchableResource($dispatchableName)
     {
-        return $this->resourcePrefix . $controllerName;
+        return $this->resourcePrefix . $dispatchableName;
     }
 
     /**

--- a/src/ZfcAcl/Model/Mapper/DispatchableResourceMapperInterface.php
+++ b/src/ZfcAcl/Model/Mapper/DispatchableResourceMapperInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ZfcAcl\Model\Mapper;
+
+/**
+ * Maps provided dispatchable names to resource names. In this case by simply adding some prefix.
+ *
+ * @todo add method to reverse mappings?
+ */
+interface DispatchableResourceMapperInterface
+{
+    /**
+     * Retrieves the resource id associated with the given dispatchable name
+     *
+     * @param string $dispatchableName
+     * @return string
+     */
+    public function getDispatchableResource($dispatchableName);
+}

--- a/src/ZfcAcl/Service/Acl.php
+++ b/src/ZfcAcl/Service/Acl.php
@@ -202,7 +202,7 @@ class Acl extends ServiceAbstract {
         return $this->roleProvider;
     }
 
-    public function setRoleProvider($roleProvider) {
+    public function setRoleProvider(RoleProvider $roleProvider) {
         $this->roleProvider = $roleProvider;
     }
 

--- a/src/ZfcAcl/Service/Acl.php
+++ b/src/ZfcAcl/Service/Acl.php
@@ -2,39 +2,39 @@
 
 namespace ZfcAcl\Service;
 
-use     Zend\EventManager\EventCollection,
-        Zend\EventManager\EventManager,
-        Zend\Acl\Acl as ZendAcl,
-        Zend\Acl\Resource,
-        Zend\Acl\Resource\GenericResource,
-        Zend\Acl\Role,
-        Zend\Acl\Role\GenericRole,
-        Zend\EventManager\Event,
-        Zend\Acl\Exception\InvalidArgumentException as ZendAclInvalidArgumentException,
-        ZfcBase\Service\ServiceAbstract,
-        ZfcAcl\Module,
-        ZfcAcl\Model\Mapper\AclLoader,
-        ZfcAcl\Service\Acl\RoleProvider,
-        InvalidArgumentException as NoStringResourceException;
+use Zend\EventManager\EventCollection,
+    Zend\EventManager\EventManager,
+    Zend\Acl\Acl as ZendAcl,
+    Zend\Acl\Resource,
+    Zend\Acl\Resource\GenericResource,
+    Zend\Acl\Role,
+    Zend\Acl\Role\GenericRole,
+    Zend\EventManager\Event,
+    Zend\Acl\Exception\InvalidArgumentException as ZendAclInvalidArgumentException,
+    ZfcBase\Service\ServiceAbstract,
+    ZfcAcl\Module,
+    ZfcAcl\Model\Mapper\AclLoader,
+    ZfcAcl\Service\Acl\RoleProvider,
+    InvalidArgumentException as NoStringResourceException;
 
 class Acl extends ServiceAbstract {
     protected $module;
     protected $acl;
     protected $aclLoader;
     protected $roleProvider;
-    
+
     /**
      * TODO XXX there is a bug in DI while injecting a module works with constructor only!
-     * @param Module $module 
+     * @param Module $module
      */
     public function __construct(Module $module) {
         $this->setModule($module);
     }
-    
+
     public function isAllowed($resource = null, $privilege = null) {
         $acl = $this->getAcl();
         $roleId = $this->getRoleId();
-        
+
         //matuszemi: we want to get resource object here at all times
         if(!$resource instanceof Resource) {
             $result = $this->triggerEvent('resolveResource', array(
@@ -53,9 +53,9 @@ class Acl extends ServiceAbstract {
                 $resource = new GenericResource($resource);
             }
         }
-        
+
         if(!$acl->hasResource($resource)) {
-            
+
             //mz: this is your chance to load resource ACL up!
             $this->triggerEvent('loadResource', array(
                 'acl' => $acl,
@@ -63,7 +63,7 @@ class Acl extends ServiceAbstract {
                 'resource' => $resource,
                 'privilege' => $privilege
             ));
-            
+
             //mz: we don't want to cache dynamic resources - this should be removed?
             //persist (possibly) update ACL into cache mechanism e.g. session etc.
 //            $this->triggerEvent('cacheAcl', array(
@@ -73,17 +73,17 @@ class Acl extends ServiceAbstract {
 //                'privilege' => $privilege
 //            ));
         }
-        
+
         try {
             $ret = $acl->isAllowed($roleId, $resource, $privilege);
-            
+
             return $ret;
         } catch(ZendAclInvalidArgumentException $e) {
             //mz: in case there is still no resource/role
             return false;
         }
     }
-    
+
     public function getAcl() {
         if($this->acl === null) {
             $roleId = $this->getRoleId();
@@ -98,7 +98,7 @@ class Acl extends ServiceAbstract {
                 $this->acl = $acl;
                 return $this->acl;
             }
-            
+
             $acl = $this->getLocator()->get('Zend\Acl\Acl');
             $this->triggerEvent('loadStaticAcl', array(
                 'acl' => $acl,
@@ -108,21 +108,21 @@ class Acl extends ServiceAbstract {
                 'acl' => $acl,
                 'roleId' => $roleId,
             ));
-            
+
             $this->acl = $acl;
         }
-        
+
         return $this->acl;
     }
-    
+
     public function invalidateCache() {
         $this->triggerEvent('invalidateCache', array(
             'roleId' => $this->getRoleId(),
         ));
-        
+
         $this->acl = null;
     }
-    
+
     /**
      * @return Zend\Acl\Role
      */
@@ -131,19 +131,19 @@ class Acl extends ServiceAbstract {
         if(!$roleProvider instanceof RoleProvider) {
             throw new \RuntimeException("No role provider available");
         }
-        
+
         $role = $roleProvider->getCurrentRole();
         if(!$role instanceof Role) {
             $role = new GenericRole('guest');
         }
-        
+
         return $role;
     }
-    
+
     protected function getRoleId() {
         return $this->getRole()->getRoleId();
     }
-    
+
     //event listeners
     public function getCacheSessionAcl(Event $e) {
         //TODO DI!
@@ -151,22 +151,22 @@ class Acl extends ServiceAbstract {
         $acl = $mapper->loadByRoleId($e->getParam('role'));
         return $acl;
     }
-    
+
     public function persistCacheSessionAcl(Event $e) {
         //TODO DI!
         $mapper = $this->getLocator()->get('ZfcAcl\Model\Mapper\AclCacheSession');
         return $mapper->persist($e->getParam('acl'), $e->getParam('role'));
     }
-    
+
     public function invalidateCacheSession(Event $e) {
         //TODO DI!
         $mapper = $this->getLocator()->get('ZfcAcl\Model\Mapper\AclCacheSession');
         $mapper->invalidate($e->getParam('role'));
     }
-    
+
     protected function attachDefaultListeners() {
         $events = $this->events();
-        
+
         //AclLoaderMapper
         $aclLoader = $this->getAclLoader();
         $events->attach('loadStaticAcl', function($e) use ($aclLoader) {
@@ -174,22 +174,22 @@ class Acl extends ServiceAbstract {
                 $aclLoader->loadAclByRoleId($e->getParam('acl'), $e->getParam('roleId'));
             }
         });
-        
+
         if($this->getModule()->getOption('enable_cache', false)) {
             $events->attach('getAcl', array($this, 'getCacheSessionAcl'));
             $events->attach('staticAclLoaded', array($this, 'persistCacheSessionAcl'));
             $events->attach('invalidateCache', array($this, 'invalidateCacheSessionCache'));
         }
     }
-    
+
     public function setModule(Module $module) {
         $this->module = $module;
     }
-    
+
     public function getModule() {
         return $this->module;
     }
-    
+
     public function getAclLoader() {
         return $this->aclLoader;
     }
@@ -197,7 +197,7 @@ class Acl extends ServiceAbstract {
     public function setAclLoader(AclLoader $aclLoader) {
         $this->aclLoader = $aclLoader;
     }
-    
+
     public function getRoleProvider() {
         return $this->roleProvider;
     }


### PR DESCRIPTION
This one should provide functionality required to filter access to controllers (dispatchables).

I have only introduced the concept of "dispatchables", the "action" in requests is ignored by `ZfcAcl\Guard\Dispatch' guard (sorry @Akrabat).

The `dispatchable -> resource-id` mapper is very simplified, and by default simply attaches `dispatchable/` in front of the controller name. An interface has been added to allow custom mapper logic to be injected anyway.
