### PR TITLE
Adds action support to dispatchable guard

### DIFF
--- a/src/ZfcAcl/Guard/Dispatch.php
+++ b/src/ZfcAcl/Guard/Dispatch.php
@@ -33,8 +33,9 @@ class Dispatch implements Guard
     public function dispatch(MvcEvent $e)
     {
         // @todo this logic should somehow be shared with Zend\Mvc\Application
-        $controller = $e->getRouteMatch()->getParam('controller', 'not-found');
-        $action = $e->getRouteMatch()->getParam('action', null);
+        $routeMatch = $e->getRouteMatch();
+        $controller = $routeMatch->getParam('controller', 'not-found');
+        $action = $routeMatch->getParam('action', null);
         if (!$controller) {
             // Can't check against null
             return;

--- a/src/ZfcAcl/Guard/Dispatch.php
+++ b/src/ZfcAcl/Guard/Dispatch.php
@@ -33,14 +33,15 @@ class Dispatch implements Guard
     public function dispatch(MvcEvent $e)
     {
         // @todo this logic should somehow be shared with Zend\Mvc\Application
-        $controller = $e->getRouteMatch()->getParam('controller', 'not-found');
+		$controller = $e->getRouteMatch()->getParam('controller', 'not-found');
+		$action = $e->getRouteMatch()->getParam('action', 'index');
         if (!$controller) {
             // Can't check against null
             return;
         }
         $controllerResource = $this->dispatchableResourceMapper->getDispatchableResource($controller);
 
-        if (!$this->aclService->isAllowed($controllerResource)) {
+        if (!$this->aclService->isAllowed($controllerResource, $action)) {
             throw new UnauthorizedException(
                 $this->aclService->getRole()->getRoleId() . ' is not allowed to access dispatchable '
                 . $controller . ' (' . $controllerResource . ')'

--- a/src/ZfcAcl/Guard/Dispatch.php
+++ b/src/ZfcAcl/Guard/Dispatch.php
@@ -33,8 +33,8 @@ class Dispatch implements Guard
     public function dispatch(MvcEvent $e)
     {
         // @todo this logic should somehow be shared with Zend\Mvc\Application
-		$controller = $e->getRouteMatch()->getParam('controller', 'not-found');
-		$action = $e->getRouteMatch()->getParam('action', 'index');
+        $controller = $e->getRouteMatch()->getParam('controller', 'not-found');
+        $action = $e->getRouteMatch()->getParam('action', null);
         if (!$controller) {
             // Can't check against null
             return;


### PR DESCRIPTION
Adds action support to the dispatchable guard.
Controller actions are defined by being a privilege.

This allows for stuff like this;

'allow/user-login' => array(
 null,
 'dispatchable/user',
 array('login'),
),
'allow/user' => array(
 array('user', 'admin'),
 'dispatchable/user',
 array('profile', 'logout'),
),
